### PR TITLE
Converted to protocol-relative URLs to automatically detect HTTPS

### DIFF
--- a/js/alina-beta-0.1.js
+++ b/js/alina-beta-0.1.js
@@ -14,7 +14,7 @@ function alina(type){
 	if(!window.jQuery){
 		   var script = document.createElement('script');
 		   script.type = "text/javascript";
-		   script.src = "https://code.jquery.com/jquery-1.11.1.min.js";
+		   script.src = "//code.jquery.com/jquery-1.11.1.min.js";
 		   document.getElementsByTagName('head')[0].appendChild(script);
 	}
 
@@ -29,7 +29,7 @@ function alina(type){
 
 			$(selector).each(function(){
 				productId = $(selector).html();
-				$.getJSON('https://alan-maybe588.rhcloud.com/cloud/models/recommend/?callback=?','productId='+productId,
+				$.getJSON('//alan-maybe588.rhcloud.com/cloud/models/recommend/?callback=?','productId='+productId,
 					function(res){
    						 console.log(res)
 					});
@@ -43,7 +43,7 @@ function alina(type){
 
 			productId = pref.split(endSearch)[0];
 			
-			$.getJSON('https://alan-maybe588.rhcloud.com/cloud/models/recommend/?productId='+productId+'&callback=?',
+			$.getJSON('//alan-maybe588.rhcloud.com/cloud/models/recommend/?productId='+productId+'&callback=?',
 					function(res){
    						 console.log(res)
 					});
@@ -60,7 +60,7 @@ function alina(type){
 
 				$(i).on(settings.hotspots[i][j]['action'], settings.hotspots[i][j], function(event){
 					
-					$.getJSON('https://alan-maybe588.rhcloud.com/cloud/models/recommend/?rating='+event.data['rating']+'&action='+event.data['action']+'&productId='+event.data['productId']+'&callback=?',function(res){
+					$.getJSON('//alan-maybe588.rhcloud.com/cloud/models/recommend/?rating='+event.data['rating']+'&action='+event.data['action']+'&productId='+event.data['productId']+'&callback=?',function(res){
     				
     						console.log(res);
 					});
@@ -78,7 +78,7 @@ function alina(type){
 
 		setTimeout(function(){
 
-			$.getJSON('https://alan-maybe588.rhcloud.com/cloud/models/activity/?productId='+productId+'&callback=?',function(res){
+			$.getJSON('//alan-maybe588.rhcloud.com/cloud/models/activity/?productId='+productId+'&callback=?',function(res){
     				
     				alinaCallback5555(res);
 			});


### PR DESCRIPTION
This will load HTTPS only on secure connections, and use HTTP otherwise to avoid the overhead of HTTPS unless it's necessary.

Ref: http://billpatrianakos.me/blog/2013/04/18/protocol-relative-urls/
